### PR TITLE
Make print_msec option work

### DIFF
--- a/lib/rexbug.ex
+++ b/lib/rexbug.ex
@@ -227,7 +227,7 @@ defmodule Rexbug do
   """
   def start(trace_pattern, options) do
     with {:ok, options} <- Translator.translate_options(options),
-         options = Keyword.merge(default_options(), options),
+         options = add_default_options(options),
          {:ok, translated} <- Translator.translate(trace_pattern) do
       :redbug.start(translated, options)
     end
@@ -282,9 +282,13 @@ defmodule Rexbug do
     :ok
   end
 
-  defp default_options() do
-    [
-      print_fun: &Rexbug.Printing.print/1
+  defp add_default_options(opts) do
+    print_fun = fn t -> Rexbug.Printing.print_with_opts(t, opts) end
+
+    default_options = [
+      print_fun: print_fun
     ]
+
+    Keyword.merge(default_options, opts)
   end
 end

--- a/lib/rexbug/printing.ex
+++ b/lib/rexbug/printing.ex
@@ -166,7 +166,9 @@ defmodule Rexbug.Printing do
   """
   @spec print(tuple()) :: :ok
   def print(message) do
-    IO.puts("\n" <> format(message))
+    # this is not a 2 arg function just so that no-one passes it as the
+    # print_fun to :redbug, the second argument is not an accumulator
+    print_with_opts(message, [])
   end
 
   @doc false

--- a/test/rexbug/printing_test.exs
+++ b/test/rexbug/printing_test.exs
@@ -20,7 +20,7 @@ defmodule Rexbug.PrintingTest do
     end
   end
 
-  describe "Printing.format/1" do
+  describe "Printing.format/_" do
     test "sample call on Elixir module" do
       msg = {
         :call,
@@ -81,6 +81,15 @@ defmodule Rexbug.PrintingTest do
 
       assert "# 22:20:04 #PID<0.182.0> IEx.Evaluator.init/4\n# <<< {1, :foo}" ==
                Printing.format(msg)
+    end
+
+    test "can print with print_msec option set to true" do
+      msg =
+        {:recv, {1, :foo}, {:c.pid(0, 182, 0), {IEx.Evaluator, :init, 4}}, {22, 20, 4, 760_169}}
+
+      assert "# 22:20:04 #PID" <> _rest = Printing.format(msg)
+      assert "# 22:20:04 #PID" <> _rest = Printing.format(msg, print_msec: false)
+      assert "# 22:20:04.760 #PID" <> _rest = Printing.format(msg, print_msec: true)
     end
   end
 


### PR DESCRIPTION
Looks like it works:

```elixir
iex(1)> Rexbug.start("Map.take/_")
{102, 2}
iex(2)> Map.take(%{}, [:a])
%{}
        
# 17:12:41 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take(%{}, [:a])
        
# 17:12:41 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take([:a], %{}, [])
        
# 17:12:41 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take([], %{}, [])
redbug done, timeout - 3
iex(3)> Rexbug.start("Map.take/_")
{102, 2}
redbug done, timeout - 0                  
iex(4)> Rexbug.start("Map.take/_", print_msec: true)
{102, 2}
iex(5)> Map.take(%{}, [:a])                         
%{}

# 17:13:20.130 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take(%{}, [:a])
        
# 17:13:20.130 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take([:a], %{}, [])
        
# 17:13:20.130 #PID<0.225.0> IEx.Evaluator.init/4
# Map.take([], %{}, [])
redbug done, timeout - 3

```