### PR TITLE
Fix problematic edge cases with :send and :receive

### DIFF
--- a/test/rexbug/printing_test.exs
+++ b/test/rexbug/printing_test.exs
@@ -18,6 +18,19 @@ defmodule Rexbug.PrintingTest do
       msg = [what: "is this?"]
       assert msg == Printing.from_erl(msg)
     end
+
+    test "handles a problematic message with code_server" do
+      pid = self()
+
+      msg =
+        {:send,
+         {
+           {:code_call, pid, {:ensure_loaded, Inspect}},
+           :code_server
+         }, {pid, {IEx.Evaluator, :init, 4}}, {18, 2, 37, 897_140}}
+
+      assert %Printing.Send{} = Printing.from_erl(msg)
+    end
   end
 
   describe "Printing.format/_" do


### PR DESCRIPTION
This is to tackle 2 different problems which I noticed when running `Rexbug.start([:send, :receive], procs: :all)` as soon as I started iex:


One with `{port, charlist}` where Rexbug was expecting `{pid, mfa`}
```elixir
# 17:39:20 #PID<0.193.0> IEx.Evaluator.init/4
# #PID<0.65.0> :group.server/3 <<< {:io_request, #PID<0.193.0>, #Reference<0.1125660530.3109552135.233867>, {:get_geometry, :columns}}
        
# 17:39:20 #PID<0.65.0> :group.server/3
# #PID<0.63.0> (:user_drv) <<< {#PID<0.65.0>, :tty_geometry}
redbug done, function_clause - [{'Elixir.Rexbug.Printing.MFA',from_erl,
                                 ["tty_sl"],
                                 [{file,"lib/rexbug/printing.ex"},{line,27}]},
                                {'Elixir.Rexbug.Printing',from_erl,1,
                                 [{file,"lib/rexbug/printing.ex"},{line,225}]},
                                {'Elixir.Rexbug.Printing',format,2,
                                 [{file,"lib/rexbug/printing.ex"},{line,183}]},
                                {'Elixir.Rexbug.Printing',print_with_opts,2,
                                 [{file,"lib/rexbug/printing.ex"},{line,177}]},
                                {redbug,'-wrap_print_fun/1-fun-0-',3,
                                 [{file,
                                   "/home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl"},
                                  {line,313}]},
                                {lists,foldl,3,
                                 [{file,"lists.erl"},{line,1263}]},
                                {redbug,print_loop,2,
                                 [{file,
                                   "/home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl"},
                                  {line,529}]}]
iex(6)> 
17:39:20.450 [error] Process #PID<0.205.0> raised an exception
** (FunctionClauseError) no function clause matching in Rexbug.Printing.MFA.from_erl/1
    (rexbug) lib/rexbug/printing.ex:27: Rexbug.Printing.MFA.from_erl('tty_sl')
    (rexbug) lib/rexbug/printing.ex:225: Rexbug.Printing.from_erl/1
    (rexbug) lib/rexbug/printing.ex:183: Rexbug.Printing.format/2
    (rexbug) lib/rexbug/printing.ex:177: Rexbug.Printing.print_with_opts/2
    (redbug) /home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl:313: anonymous fn/3 in :redbug.wrap_print_fun/1
    (stdlib) lists.erl:1263: :lists.foldl/3
    (redbug) /home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl:529: :redbug.print_loop/2
```

One with `:code_server` when Rexbug was expecting `{pid, mfa}`:
```elixir
18:02:38.090 [error] Process #PID<0.205.0> raised an exception
** (FunctionClauseError) no function clause matching in Rexbug.Printing.represent/2
    (rexbug) lib/rexbug/printing.ex:246: Rexbug.Printing.represent({:send, {{:code_call, #PID<0.202.0>, {:ensure_loaded, Inspect}}, :code_server}, {#PID<0.202.0>, {IEx.Evaluator, :init, 4}}, {18, 2, 37, 897140}}, [procs: :all, msgs: 1000])
    (rexbug) lib/rexbug/printing.ex:177: Rexbug.Printing.print_with_opts/2
    (redbug) /home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl:313: anonymous fn/3 in :redbug.wrap_print_fun/1
    (stdlib) lists.erl:1263: :lists.foldl/3
    (redbug) /home/nietaki/repos/rexbug/deps/redbug/src/redbug.erl:529: :redbug.print_loop/2
```

This is less thorough than I would have liked, but looks like it fixes both of the problems.