### PR TITLE
Fix FunctionClauseError in Inspect.Algebra.container_each/6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.3
-elixir 1.7.4-otp-21
+elixir 1.11.3-otp-23
+erlang 23.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       elixir: 1.8.2
     - otp_release: 22.0
       elixir: 1.8.2
+    - otp_release: 23.0
+      elixir: 1.11.3
       env: LATEST=1
 env:
   global:

--- a/lib/rexbug/printing/utils.ex
+++ b/lib/rexbug/printing/utils.ex
@@ -1,7 +1,7 @@
 defmodule Rexbug.Printing.Utils do
   @moduledoc false
 
-  @printing_opts [limit: -1]
+  @printing_opts [limit: :infinity]
 
   def printing_inspect(term) do
     inspect(term, @printing_opts)


### PR DESCRIPTION
Fixes an error introduced in Elixir 1.11.0 when they reworked the guards on the `Inspect.Algebra.container_each/6` function.

Reported error (PID varies with usage, so is omitted):

```
[error] Process #PID<...> raised an exception
** (FunctionClauseError) no function clause matching in Inspect.Algebra.container_each/6
```

Fixes #47 